### PR TITLE
feat(nanvix): add expat_config.h for cross-compilation

### DIFF
--- a/expat/.gitignore
+++ b/expat/.gitignore
@@ -17,7 +17,6 @@ config.cache
 config.log
 config.status
 expat_config.h.in
-expat_config.h
 libtool
 expat.ncb
 expat.opt
@@ -39,3 +38,5 @@ source__R*
 /libexpat*.dll
 /changelog
 *~
+*.o
+*.a

--- a/expat/expat_config.h
+++ b/expat/expat_config.h
@@ -1,0 +1,24 @@
+#define BYTEORDER 1234
+#define HAVE_BCOPY 1
+#define HAVE_DLFCN_H 1
+#define HAVE_FCNTL_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UNISTD_H 1
+#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+#define PACKAGE_NAME "expat"
+#define PACKAGE_STRING "expat 2.6.4"
+#define PACKAGE_TARNAME "expat"
+#define PACKAGE_URL ""
+#define PACKAGE_VERSION "2.6.4"
+#define STDC_HEADERS 1
+#define XML_CONTEXT_BYTES 1024
+#define XML_DTD 1
+#define XML_NS 1


### PR DESCRIPTION
## Summary

Adds a pre-configured `expat/expat_config.h` for cross-compilation on Nanvix (and other POSIX-compatible targets) so autotools/CMake are not required during the build.

## Motivation

The bootstrap script previously generated `expat_config.h` inline during the build. By committing it directly, cross-compilation environments can build libexpat without running autotools or CMake.

## Changes
- **expat/expat_config.h**: New file with Nanvix-compatible configuration defines
- **expat/.gitignore**: Track `expat_config.h`, add `*.o` and `*.a` patterns