### PR TITLE
ci: include test ELFs in release packages

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -193,6 +193,7 @@ jobs:
           sysroot/
             lib/libexpat.a
             include/{expat.h,expat_external.h}
+            bin/expat_test.elf
           \`\`\`
 
           **Dependencies:** None (standalone library)" \

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -215,10 +215,12 @@ package: all
 	$(eval ARTIFACT_NAME := expat-$(PLATFORM)-$(PROCESS_MODE))
 	rm -rf dist/$(ARTIFACT_NAME)
 	mkdir -p dist/$(ARTIFACT_NAME)/sysroot/lib \
-	dist/$(ARTIFACT_NAME)/sysroot/include
+	dist/$(ARTIFACT_NAME)/sysroot/include \
+	dist/$(ARTIFACT_NAME)/sysroot/bin
 	cp -f $(STATICLIB) dist/$(ARTIFACT_NAME)/sysroot/lib/
 	cp -f expat/lib/expat.h dist/$(ARTIFACT_NAME)/sysroot/include/
 	cp -f expat/lib/expat_external.h dist/$(ARTIFACT_NAME)/sysroot/include/
+	-cp -f $(TEST_PROGS) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
 	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C dist/$(ARTIFACT_NAME) sysroot
 	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
 	@echo "  Contents:"


### PR DESCRIPTION
Include `expat_test.elf` in `sysroot/bin/` of release packages so upstream verification can use pre-built test artifacts rather than compiling inline C programs.

- Add `sysroot/bin` directory and copy test ELF in `package` target
- Update CI workflow release notes to document `bin/expat_test.elf`