### PR TITLE
ci: remove non-build workflow dispatch/listener

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -219,20 +219,6 @@ jobs:
             --latest \
             release-assets/*.tar.bz2
 
-      - name: Trigger Dependent Workflows
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-        run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
-          echo "Triggering cpython workflow..."
-          gh api repos/nanvix/cpython/dispatches \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -f event_type="expat-release" \
-            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-            -f "client_payload[expat_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
-
   report-failure:
     needs: [build]
     if: >-


### PR DESCRIPTION
This PR removes repository_dispatch links that do not correspond to actual build-time dependencies in this repository's CI workflow.